### PR TITLE
Persist DHT data on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a minimal Plan9-inspired distributed filesystem implemented in D.
 It mirrors the early layout from the `internetcomputer` project and stores file blocks
-in a simple in-memory DHT. The tree contains `/users`, `/dev`, `/proc` and
+in a small disk-backed DHT so data survives restarts. The tree contains `/users`, `/dev`, `/proc` and
 `/hardware` directories similar to Plan9.
 
 Run `make` to build the server binary using `ldc2`.

--- a/distributed_fs/README.md
+++ b/distributed_fs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a lightweight Plan9-style filesystem implemented in D.
 It reuses ideas from the early `internetcomputer` repository and stores data
-blocks in a small in-memory DHT.
+blocks in a small disk-backed DHT so state persists between runs.
 
 Modules included:
 
@@ -12,7 +12,7 @@ Modules included:
 - `network/` – coordination stubs
 - `crypto/` – placeholder crypto routines
 - `metadata/` – asynchronous metadata buffer
-- `storage/` – simple in-memory DHT providing RAID-like redundancy
+- `storage/` – disk-backed DHT providing RAID-like redundancy
 
 Running `make` builds the server which initializes a small filesystem tree and
 stores an example file in the DHT.

--- a/distributed_fs/storage/dht.d
+++ b/distributed_fs/storage/dht.d
@@ -2,19 +2,38 @@ module distributed_fs.storage.dht;
 
 import std.stdio;
 import std.string;
+import std.file : mkdirRecurse, exists, dirEntries, read, write, SpanMode;
+import std.path : buildPath, baseName;
+import std.conv : to;
 
 /// Simple in-memory DHT used for examples.
 struct Dht {
     // vector of node tables mapping id -> data
     private ubyte[][string][] nodes;
     size_t redundancy;
+    string basePath;
 
-    this(size_t nodeCount, size_t redundancy) {
+    this(size_t nodeCount, size_t redundancy, string path) {
         nodes.length = nodeCount;
         foreach(i; 0 .. nodeCount) {
             nodes[i] = ubyte[][string].init;
         }
         this.redundancy = redundancy;
+        this.basePath = path;
+        mkdirRecurse(basePath);
+        foreach(i; 0 .. nodeCount) {
+            auto dir = buildPath(basePath, "node" ~ to!string(i));
+            mkdirRecurse(dir);
+            if (exists(dir)) {
+                foreach(entry; dirEntries(dir, SpanMode.shallow)) {
+                    if(entry.isFile) {
+                        auto data = cast(ubyte[])read(entry.name);
+                        auto id = baseName(entry.name);
+                        nodes[i][id] = data.dup;
+                    }
+                }
+            }
+        }
     }
 
     static size_t hash(string key) {
@@ -29,14 +48,21 @@ struct Dht {
         foreach(replica; 0 .. redundancy) {
             auto idx = (hash(id) + replica) % nodes.length;
             nodes[idx][id] = data.dup;
+            auto dir = buildPath(basePath, "node" ~ to!string(idx));
+            auto file = buildPath(dir, id);
+            write(file, data);
         }
     }
 
     ubyte[] get(string id) const {
-        foreach(table; nodes) {
+        foreach(idx, table; nodes) {
             auto ptr = id in table;
             if(ptr !is null) {
                 return (*ptr).dup;
+            }
+            auto file = buildPath(basePath, "node" ~ to!string(idx), id);
+            if (exists(file)) {
+                return cast(ubyte[])read(file);
             }
         }
         return null;
@@ -46,8 +72,8 @@ struct Dht {
 __gshared Dht gDht;
 
 /// Initialize global DHT instance
-void initDht(size_t nodes, size_t redundancy) {
-    gDht = Dht(nodes, redundancy);
+void initDht(size_t nodes, size_t redundancy, string path = "dht_data") {
+    gDht = Dht(nodes, redundancy, path);
 }
 
 /// Store a block in the global DHT


### PR DESCRIPTION
## Summary
- persist DHT data to a local `dht_data` directory so the filesystem survives restarts
- mention disk-backed DHT in docs

## Testing
- `apt-get update`
- `apt-get install -y ldc`
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_685efaabc7d48327a87e2c87ce575c07